### PR TITLE
Update main.go

### DIFF
--- a/cmd/flux-cluster-generator/main.go
+++ b/cmd/flux-cluster-generator/main.go
@@ -1,630 +1,82 @@
-// cmd/flux-cluster-generator/main.go
 package main
 
 import (
-	"context"
 	"flag"
-	"fmt"
-	"maps"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/client-go/util/workqueue"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/go-logr/logr"
-)
-
-var rsipGVK = schema.GroupVersionKind{
-	Group:   "fluxcd.controlplane.io",
-	Version: "v1",
-	Kind:    "ResourceSetInputProvider",
-}
-
-// CLI flags
-var (
-	watchNamespacesCSV        string
-	rsipNamespace             string
-	labelSelectorStr          string
-	secretKey                 string
-	rsipNamePrefix            string
-	clusterNameKey            string
-	projectLabelKey           string
-	copyLabelKeysCSV          string
-	copyLabelPrefixesCSV      string
-	namespaceLabelSelectorStr string
+	"github.com/loft-demos/flux-cluster-generator/internal/controller"
 )
 
 func main() {
+	// ----- logging / flags
 	z := zap.Options{Development: false}
 	z.BindFlags(flag.CommandLine)
 
-	flag.StringVar(&watchNamespacesCSV, "watch-namespaces", "", "Comma-separated namespaces to watch for Secrets. Empty = all namespaces")
-	flag.StringVar(&rsipNamespace, "rsip-namespace", "flux-apps", "Namespace to create RSIPs in")
-	flag.StringVar(&labelSelectorStr, "label-selector", "", "Label selector for source Secrets, e.g. env=dev,team=payments,fluxcd.io/secret-type=cluster")
-	flag.StringVar(&secretKey, "secret-key", "config", "Key in Secret.data that contains the kubeconfig")
-	flag.StringVar(&rsipNamePrefix, "rsip-name-prefix", "inputs-", "Prefix for generated RSIP names")
-	flag.StringVar(&clusterNameKey, "cluster-name-label-key", "vci.flux.loft.sh/name", "Label key on the Secret to derive cluster name; fallback to Secret name")
-	flag.StringVar(&projectLabelKey, "project-label-key", "vci.flux.loft.sh/project", "Label key on the Secret containing the VCI project")
-	flag.StringVar(&copyLabelKeysCSV, "copy-label-keys", "env,team,region", "Comma-separated label KEYS to copy from Secret to RSIP")
-	flag.StringVar(&copyLabelPrefixesCSV, "copy-label-prefixes", "", "Comma-separated label KEY PREFIXES to copy (e.g. flux-app/)")
-	flag.StringVar(&namespaceLabelSelectorStr, "namespace-label-selector", "", "Label selector for Namespaces to include (e.g. flux-cluster-generator-enabled=true)")
+	opts := controller.Options{} // see options.go
+	flag.StringVar(&opts.RSIPNamespace, "rsip-namespace", "flux-apps", "Namespace to create RSIPs in")
+	flag.StringVar(&opts.SecretKey, "secret-key", "config", "Key in Secret.data with kubeconfig")
+	flag.StringVar(&opts.RSIPNamePrefix, "rsip-name-prefix", "inputs-", "Prefix for RSIP names")
+	flag.StringVar(&opts.ClusterNameKey, "cluster-name-label-key", "vci.flux.loft.sh/name", "Label key for cluster name")
+	flag.StringVar(&opts.ProjectLabelKey, "project-label-key", "vci.flux.loft.sh/project", "Label key for project")
+	flag.StringVar(&opts.LabelSelectorStr, "label-selector", "", "Selector for source Secrets")
+	flag.StringVar(&opts.NamespaceLabelSelectorStr, "namespace-label-selector", "", "Selector for Namespaces to include")
+	flag.StringVar(&opts.CopyLabelKeysCSV, "copy-label-keys", "env,team,region", "Label KEYS to copy")
+	flag.StringVar(&opts.CopyLabelPrefixesCSV, "copy-label-prefixes", "", "Label KEY PREFIXES to copy (e.g. flux-app/)")
+	flag.StringVar(&opts.WatchNamespacesCSV, "watch-namespaces", "", "Optional list of namespaces to watch")
+	flag.IntVar(&opts.MaxConcurrent, "concurrency", 2, "Max concurrent reconciles")
+	flag.DurationVar(&opts.CacheSyncTimeout, "cache-sync-timeout", 2*time.Minute, "Informer cache sync timeout")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&z)))
-	logger := ctrl.Log.WithName("setup")
 
+	// ----- scheme / manager
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{Scheme: scheme})
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                server.Options{BindAddress: ":8080"},
+		HealthProbeBindAddress: ":8081",
+		LeaderElection:         true,
+		LeaderElectionID:       "flux-cluster-generator",
+	})
 	if err != nil {
-		logger.Error(err, "unable to start manager")
-		os.Exit(1)
+		panic(err)
 	}
 
-	c := mgr.GetClient()
-	apiReader := mgr.GetAPIReader() // uncached
+	// Expand CSVs to slices/sets once
+	opts.CopyLabelKeys = controller.SplitNonEmpty(opts.CopyLabelKeysCSV)
+	opts.CopyLabelPrefixes = controller.SplitNonEmpty(opts.CopyLabelPrefixesCSV)
+	opts.WatchNamespaces = controller.SplitNonEmpty(opts.WatchNamespacesCSV)
+	opts.LabelSelector = controller.ParseSelectorOrDie(opts.LabelSelectorStr)
+	opts.NamespaceSelector = controller.ParseSelectorOrDie(opts.NamespaceLabelSelectorStr)
 
-	// Secret selector
-	var secSel labels.Selector
-	if labelSelectorStr != "" {
-		if parsed, err := labels.Parse(labelSelectorStr); err == nil {
-			secSel = parsed
-		} else {
-			logger.Error(err, "invalid --label-selector")
-			os.Exit(1)
-		}
-	} else {
-		secSel = labels.Everything()
+	// ----- wire controllers
+	if err := controller.SetupNamespaceSetController(mgr, opts); err != nil {
+		panic(err)
+	}
+	if err := controller.SetupRSIPController(mgr, opts); err != nil {
+		panic(err)
 	}
 
-	copyLabelKeys := sets.New[string]()
-	for _, k := range splitNonEmpty(copyLabelKeysCSV) {
-		copyLabelKeys.Insert(strings.TrimSpace(k))
-	}
-	copyLabelPrefixes := splitNonEmpty(copyLabelPrefixesCSV)
+	// healthz/readyz
+	_ = mgr.AddHealthzCheck("ping", healthz.Ping)
+	_ = mgr.AddReadyzCheck("ping", healthz.Ping)
 
-	allowedNS := newThreadSafeSet()
-
-	reconciler := &SecretMirrorReconciler{
-		Client:            c,
-		APIReader:         apiReader,
-		RSIPNamespace:     rsipNamespace,
-		Selector:          secSel,
-		SecretKey:         secretKey,
-		RSIPNamePrefix:    rsipNamePrefix,
-		ClusterNameKey:    clusterNameKey,
-		ProjectLabelKey:   projectLabelKey,
-		CopyLabelKeys:     copyLabelKeys,
-		CopyLabelPrefixes: copyLabelPrefixes,
-		AllowedNS:         allowedNS,
-	}
-
-	// Namespace allowlist maintenance
-	nsSel := labels.Everything()
-	if namespaceLabelSelectorStr != "" {
-		if s, err := labels.Parse(namespaceLabelSelectorStr); err == nil {
-			nsSel = s
-		} else {
-			logger.Error(err, "invalid --namespace-label-selector")
-			os.Exit(1)
-		}
-	}
-
-	// Seed allowlist
-	{
-		var nsList corev1.NamespaceList
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := apiReader.List(ctx, &nsList); err != nil {
-			logger.Error(err, "failed to list namespaces at startup")
-			os.Exit(1)
-		}
-		for i := range nsList.Items {
-			if nsSel.Matches(labels.Set(nsList.Items[i].Labels)) {
-				allowedNS.Add(nsList.Items[i].Name)
-			}
-		}
-		logger.Info("seeded allowed namespaces", "count", len(allowedNS.m))
-	}
-
-	// Namespace controller
-	nsPred := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool { return nsSel.Matches(labels.Set(e.Object.GetLabels())) },
-		UpdateFunc: func(e event.UpdateEvent) bool { return nsSel.Matches(labels.Set(e.ObjectNew.GetLabels())) },
-		DeleteFunc: func(e event.DeleteEvent) bool { return true },
-		GenericFunc: func(e event.GenericEvent) bool { return nsSel.Matches(labels.Set(e.Object.GetLabels())) },
-	}
-	if err := ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Namespace{}, builder.WithPredicates(nsPred)).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		Complete(&NamespaceSetReconciler{Client: c, AllowedNS: allowedNS, Selector: nsSel}); err != nil {
-		logger.Error(err, "unable to create namespace controller")
-		os.Exit(1)
-	}
-
-	// Optional namespace watch list
-	watchNS := sets.New[string]()
-	for _, ns := range splitNonEmpty(watchNamespacesCSV) {
-		watchNS.Insert(strings.TrimSpace(ns))
-	}
-
-	// Secret controller (allow deletes for cleanup)
-	secretPred := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return (watchNS.Len() == 0 || watchNS.Has(e.Object.GetNamespace())) &&
-				secSel.Matches(labels.Set(e.Object.GetLabels())) &&
-				allowedNS.Has(e.Object.GetNamespace())
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return (watchNS.Len() == 0 || watchNS.Has(e.ObjectNew.GetNamespace())) &&
-				secSel.Matches(labels.Set(e.ObjectNew.GetLabels())) &&
-				allowedNS.Has(e.ObjectNew.GetNamespace())
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool { return true },
-		GenericFunc: func(e event.GenericEvent) bool {
-			return (watchNS.Len() == 0 || watchNS.Has(e.Object.GetNamespace())) &&
-				secSel.Matches(labels.Set(e.Object.GetLabels())) &&
-				allowedNS.Has(e.Object.GetNamespace())
-		},
-	}
-
-	if err := ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Secret{}, builder.WithPredicates(secretPred)).
-		WithOptions(controller.Options{
-			CacheSyncTimeout:        2 * time.Minute,
-			RecoverPanic:            boolPtr(true),
-			RateLimiter:             workqueue.DefaultControllerRateLimiter(),
-			MaxConcurrentReconciles: 2,
-		}).
-		Complete(reconciler); err != nil {
-		logger.Error(err, "unable to create secret controller")
-		os.Exit(1)
-	}
-
-	// Periodic GC of orphan RSIPs
-	gcLog := ctrl.Log.WithName("gc")
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		ticker := time.NewTicker(2 * time.Minute)
-		defer ticker.Stop()
-
-		if err := sweepOrphanRSIPs(ctx, gcLog, apiReader, c, rsipNamespace); err != nil {
-			gcLog.Error(err, "initial GC sweep failed")
-		}
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-ticker.C:
-				if err := sweepOrphanRSIPs(ctx, gcLog, apiReader, c, rsipNamespace); err != nil {
-					gcLog.Error(err, "periodic GC sweep failed")
-				}
-			}
-		}
-	})); err != nil {
-		logger.Error(err, "unable to add GC runnable")
-		os.Exit(1)
-	}
-
-	logger.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		logger.Error(err, "problem running manager")
-		os.Exit(1)
-	}
-}
-
-// ---- Reconcilers ----
-
-type SecretMirrorReconciler struct {
-	client.Client
-	APIReader         client.Reader
-	RSIPNamespace     string
-	Selector          labels.Selector
-	SecretKey         string
-	RSIPNamePrefix    string
-	ClusterNameKey    string
-	ProjectLabelKey   string
-	CopyLabelKeys     sets.Set[string]
-	CopyLabelPrefixes []string
-	AllowedNS         *threadSafeSet
-}
-
-func (r *SecretMirrorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := ctrl.Log.WithName("reconcile").WithValues("secret", types.NamespacedName{Name: req.Name, Namespace: req.Namespace})
-
-	// Load Secret; if gone, delete RSIP(s) by labels
-	var sec corev1.Secret
-	if err := r.Get(ctx, req.NamespacedName, &sec); err != nil {
-		return ctrl.Result{}, r.ensureRSIPAbsence(ctx, req.NamespacedName)
+		panic(err)
 	}
 
-	// Filter by namespace allowlist + label selector
-	if !r.AllowedNS.Has(sec.Namespace) || !r.Selector.Matches(labels.Set(sec.Labels)) {
-		return ctrl.Result{}, r.ensureRSIPAbsence(ctx, req.NamespacedName)
-	}
-
-	// Require kubeconfig key
-	if _, ok := sec.Data[r.SecretKey]; !ok {
-		log.Info("secret missing kubeconfig key; skipping RSIP create/update", "key", r.SecretKey)
-		return ctrl.Result{}, nil
-	}
-
-	// Names/ids
-	clusterName := sec.Labels[r.ClusterNameKey]
-	if clusterName == "" {
-		clusterName = sec.Name
-	}
-	if errs := validation.IsDNS1123Label(clusterName); len(errs) > 0 {
-		log.Info("sanitizing cluster name to DNS-1123", "errors", errs)
-		clusterName = sanitizeDNS1123(clusterName)
-	}
-
-	project := strings.TrimSpace(sec.Labels[r.ProjectLabelKey])
-	if project == "" {
-		project = projectFromNamespace(sec.Namespace)
-	}
-	project = sanitizeDNS1123(project)
-
-	// RSIP name: <prefix><project>-<cluster>
-	rsipName := r.RSIPNamePrefix
-	if project != "" {
-		rsipName += project + "-"
-	}
-	rsipName += clusterName
-
-	// Desired RSIP
-	desired := &unstructured.Unstructured{}
-	desired.SetGroupVersionKind(rsipGVK)
-	desired.SetNamespace(r.RSIPNamespace)
-	desired.SetName(rsipName)
-
-	labelsToApply := map[string]string{
-		"mirror.fluxcd.io/managed":     "true",
-		"mirror.fluxcd.io/secretNS":    sec.Namespace,
-		"mirror.fluxcd.io/secretName":  sec.Name,
-		"mirror.fluxcd.io/secretKey":   r.SecretKey,
-		"mirror.fluxcd.io/clusterName": clusterName,
-		"mirror.fluxcd.io/project":     project,
-	}
-	// Exact label keys
-	for k := range r.CopyLabelKeys {
-		if v, ok := sec.Labels[k]; ok {
-			labelsToApply[k] = v
-		}
-	}
-	// Prefixed labels
-	for k, v := range sec.Labels {
-		if hasAnyPrefix(r.CopyLabelPrefixes, k) {
-			labelsToApply[k] = v
-		}
-	}
-	desired.SetLabels(labelsToApply)
-
-	// ---- defaultValues with camelCase copies of selected labels ----
-	defaultValues := map[string]any{
-		"name":           clusterName,
-		"project":        project,
-		"kubeSecretName": sec.Name,
-		"kubeSecretKey":  r.SecretKey,
-		"kubeSecretNS":   sec.Namespace,
-	}
-	// Reserved keys we won't overwrite
-	reserved := sets.New[string]("name", "project", "kubeSecretName", "kubeSecretKey", "kubeSecretNS")
-
-	// From exact keys
-	for k := range r.CopyLabelKeys {
-		if v, ok := sec.Labels[k]; ok {
-			ck := toCamel(k)
-			if !reserved.Has(ck) {
-				defaultValues[ck] = v
-			}
-		}
-	}
-	// From prefixes
-	for k, v := range sec.Labels {
-		if hasAnyPrefix(r.CopyLabelPrefixes, k) {
-			ck := toCamel(k)
-			if !reserved.Has(ck) {
-				defaultValues[ck] = v
-			}
-		}
-	}
-
-	spec := map[string]any{
-		"type":          "Static",
-		"defaultValues": defaultValues,
-	}
-	_ = unstructured.SetNestedField(desired.Object, spec, "spec")
-	// ---------------------------------------------------------------
-
-	// Create/Update
-	var existing unstructured.Unstructured
-	existing.SetGroupVersionKind(rsipGVK)
-	if err := r.Get(ctx, types.NamespacedName{Name: rsipName, Namespace: r.RSIPNamespace}, &existing); err != nil {
-		if err := r.Create(ctx, desired); err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("created RSIP", "name", rsipName, "ns", r.RSIPNamespace)
-		return ctrl.Result{}, nil
-	}
-
-	changed := false
-	if !maps.Equal(existing.GetLabels(), desired.GetLabels()) {
-		existing.SetLabels(desired.GetLabels())
-		changed = true
-	}
-	curSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
-	desSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
-	if !mapsEqual(curSpec, desSpec) {
-		_ = unstructured.SetNestedMap(existing.Object, desSpec, "spec")
-		changed = true
-	}
-	if changed {
-		if err := r.Update(ctx, &existing); err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("updated RSIP", "name", rsipName)
-	}
-	return ctrl.Result{}, nil
-}
-
-func (r *SecretMirrorReconciler) ensureRSIPAbsence(ctx context.Context, secretNN types.NamespacedName) error {
-	log := ctrl.Log.WithName("gc")
-
-	// List by labels (works even when the Secret is already gone)
-	var list unstructured.UnstructuredList
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group: rsipGVK.Group, Version: rsipGVK.Version, Kind: rsipGVK.Kind + "List",
-	})
-	if err := r.APIReader.List(ctx, &list,
-		client.InNamespace(r.RSIPNamespace),
-		client.MatchingLabels{
-			"mirror.fluxcd.io/secretNS":   secretNN.Namespace,
-			"mirror.fluxcd.io/secretName": secretNN.Name,
-		},
-	); err != nil {
-		return err
-	}
-
-	if len(list.Items) == 0 {
-		log.Info("no RSIPs found for deleted/ignored secret", "secret", secretNN.String(), "rsipNS", r.RSIPNamespace)
-		return nil
-	}
-	for i := range list.Items {
-		if err := r.Delete(ctx, &list.Items[i]); client.IgnoreNotFound(err) != nil {
-			log.Error(err, "delete RSIP failed", "name", list.Items[i].GetName())
-		} else {
-			log.Info("deleted RSIP", "name", list.Items[i].GetName())
-		}
-	}
-	return nil
-}
-
-// ---- helpers ----
-
-type threadSafeSet struct {
-	mu sync.RWMutex
-	m  map[string]struct{}
-}
-
-func boolPtr(b bool) *bool { return &b }
-
-func newThreadSafeSet() *threadSafeSet { return &threadSafeSet{m: map[string]struct{}{}} }
-
-func (s *threadSafeSet) Has(k string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	_, ok := s.m[k]
-	return ok
-}
-func (s *threadSafeSet) Add(k string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.m[k] = struct{}{}
-}
-func (s *threadSafeSet) Delete(k string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.m, k)
-}
-
-type NamespaceSetReconciler struct {
-	client.Client
-	AllowedNS *threadSafeSet
-	Selector  labels.Selector
-}
-
-func (r *NamespaceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var ns corev1.Namespace
-	if err := r.Get(ctx, req.NamespacedName, &ns); err != nil {
-		// remove on delete/not found
-		r.AllowedNS.Delete(req.Name)
-		return ctrl.Result{}, nil
-	}
-	if r.Selector.Matches(labels.Set(ns.Labels)) {
-		r.AllowedNS.Add(ns.Name)
-	} else {
-		r.AllowedNS.Delete(ns.Name)
-	}
-	return ctrl.Result{}, nil
-}
-
-func sweepOrphanRSIPs(
-	ctx context.Context,
-	log logr.Logger,
-	reader client.Reader, // uncached
-	writer client.Client, // deletes
-	rsipNS string,
-) error {
-	var rsips unstructured.UnstructuredList
-	rsips.SetGroupVersionKind(schema.GroupVersionKind{
-		Group: rsipGVK.Group, Version: rsipGVK.Version, Kind: rsipGVK.Kind + "List",
-	})
-	if err := reader.List(ctx, &rsips, client.InNamespace(rsipNS)); err != nil {
-		return err
-	}
-	for i := range rsips.Items {
-		rsip := &rsips.Items[i]
-		lbl := rsip.GetLabels()
-		secNS, okNS := lbl["mirror.fluxcd.io/secretNS"]
-		secName, okName := lbl["mirror.fluxcd.io/secretName"]
-		if !okNS || !okName || secNS == "" || secName == "" {
-			continue
-		}
-
-		var sec corev1.Secret
-		err := reader.Get(ctx, types.NamespacedName{Namespace: secNS, Name: secName}, &sec)
-		if client.IgnoreNotFound(err) != nil {
-			log.Error(err, "secret existence check failed",
-				"rsip", rsip.GetName(), "secret", fmt.Sprintf("%s/%s", secNS, secName))
-			continue
-		}
-		if err == nil {
-			continue // secret still exists
-		}
-		if err := writer.Delete(ctx, rsip); client.IgnoreNotFound(err) != nil {
-			log.Error(err, "failed deleting orphan RSIP", "name", rsip.GetName())
-		} else {
-			log.Info("deleted orphan RSIP", "name", rsip.GetName(),
-				"secret", fmt.Sprintf("%s/%s", secNS, secName))
-		}
-	}
-	return nil
-}
-
-// ---- utils ----
-
-func splitNonEmpty(csv string) []string {
-	var out []string
-	for _, s := range strings.Split(csv, ",") {
-		if s = strings.TrimSpace(s); s != "" {
-			out = append(out, s)
-		}
-	}
-	return out
-}
-
-func sanitizeDNS1123(in string) string {
-	s := strings.ToLower(in)
-	repl := func(r rune) rune {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
-			return r
-		}
-		return '-'
-	}
-	s = strings.Map(repl, s)
-	s = strings.Trim(s, "-")
-	if len(s) == 0 {
-		return "id"
-	}
-	if len(s) > 63 {
-		return s[:63]
-	}
-	return s
-}
-
-func hasAnyPrefix(prefixes []string, key string) bool {
-	for _, p := range prefixes {
-		if p = strings.TrimSpace(p); p != "" && strings.HasPrefix(key, p) {
-			return true
-		}
-	}
-	return false
-}
-
-// Best-effort derive project from namespace (supports "p-<project>")
-func projectFromNamespace(ns string) string {
-	if strings.HasPrefix(ns, "p-") && len(ns) > 2 {
-		return ns[2:]
-	}
-	return ""
-}
-
-// Deep compare two map[string]any (used for spec drift)
-func mapsEqual(a, b map[string]any) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, va := range a {
-		vb, ok := b[k]
-		if !ok {
-			return false
-		}
-		switch at := va.(type) {
-		case map[string]any:
-			bt, ok := vb.(map[string]any)
-			if !ok {
-				return false
-			}
-			if !mapsEqual(at, bt) {
-				return false
-			}
-		default:
-			if fmt.Sprintf("%v", va) != fmt.Sprintf("%v", vb) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-// toCamel converts label keys like "flux-app/podinfo", "team-name", "env.region"
-// into "fluxAppPodinfo", "teamName", "envRegion". Non-alnum are treated as separators.
-func toCamel(s string) string {
-	if s == "" {
-		return s
-	}
-	// Replace common separators with spaces, then title-case chunks and join.
-	sep := func(r rune) bool {
-		switch r {
-		case '-', '_', '.', '/', ':':
-			return true
-		default:
-			return false
-		}
-	}
-	parts := strings.FieldsFunc(s, sep)
-	if len(parts) == 0 {
-		return s
-	}
-	for i := range parts {
-		parts[i] = strings.TrimSpace(parts[i])
-	}
-	// first chunk lowerCamel, others TitleCase
-	out := strings.ToLower(parts[0])
-	for _, p := range parts[1:] {
-		if p == "" {
-			continue
-		}
-		out += strings.ToUpper(p[:1]) + strings.ToLower(p[1:])
-	}
-	// strip non-alnum (just in case)
-	clean := strings.Builder{}
-	for _, r := range out {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-			clean.WriteRune(r)
-		}
-	}
-	return clean.String()
+	_ = os.Stdout.Sync()
+	_ = strings.Builder{} // avoid unused imports on some toolchains
 }

--- a/internal/controller/options.go
+++ b/internal/controller/options.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type Options struct {
+	// core behavior
+	RSIPNamespace string
+	SecretKey     string
+	RSIPNamePrefix string
+	ClusterNameKey string
+	ProjectLabelKey string
+
+	// selectors / filters (raw strings for flags)
+	LabelSelectorStr          string
+	NamespaceLabelSelectorStr string
+	WatchNamespacesCSV        string
+	CopyLabelKeysCSV          string
+	CopyLabelPrefixesCSV      string
+
+	// parsed / derived
+	LabelSelector     labels.Selector
+	NamespaceSelector labels.Selector
+	WatchNamespaces   []string
+	CopyLabelKeys     []string
+	CopyLabelPrefixes []string
+
+	// tuning
+	MaxConcurrent     int
+	CacheSyncTimeout  time.Duration
+}

--- a/internal/controller/predicates.go
+++ b/internal/controller/predicates.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"log"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func ParseSelectorOrDie(s string) labels.Selector {
+	if s == "" {
+		return labels.Everything()
+	}
+	parsed, err := labels.Parse(s)
+	if err != nil {
+		log.Fatalf("invalid selector %q: %v", s, err)
+	}
+	return parsed
+}
+
+func SplitNonEmpty(csv string) []string {
+	if csv == "" {
+		return nil
+	}
+	ps := strings.Split(csv, ",")
+	out := make([]string, 0, len(ps))
+	for _, p := range ps {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/controller/rsip_reconciler.go
+++ b/internal/controller/rsip_reconciler.go
@@ -1,0 +1,330 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var rsipGVK = schema.GroupVersionKind{
+	Group:   "fluxcd.controlplane.io",
+	Version: "v1",
+	Kind:    "ResourceSetInputProvider",
+}
+
+type SecretMirrorReconciler struct {
+	client.Client
+	APIReader client.Reader
+
+	Opts Options
+
+	// in-memory allow-list for Namespaces
+	allowedNS *threadSafeSet
+}
+
+func SetupRSIPController(mgr ctrl.Manager, opts Options) error {
+	allowed := newThreadSafeSet()
+
+	r := &SecretMirrorReconciler{
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Opts:      opts,
+		allowedNS: allowed,
+	}
+
+	// Seed allowlist at start
+	var nsList corev1.NamespaceList
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := mgr.GetAPIReader().List(ctx, &nsList); err == nil {
+		for i := range nsList.Items {
+			if opts.NamespaceSelector.Matches(labels.Set(nsList.Items[i].Labels)) {
+				allowed.Add(nsList.Items[i].Name)
+			}
+		}
+	}
+
+	// Namespace controller (keeps allowlist up to date)
+	nsPred := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return opts.NamespaceSelector.Matches(labels.Set(e.Object.GetLabels())) },
+		UpdateFunc: func(e event.UpdateEvent) bool { return opts.NamespaceSelector.Matches(labels.Set(e.ObjectNew.GetLabels())) },
+		DeleteFunc: func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return opts.NamespaceSelector.Matches(labels.Set(e.Object.GetLabels())) },
+	}
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}, builder.WithPredicates(nsPred)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Complete(&NamespaceSetReconciler{Client: mgr.GetClient(), AllowedNS: allowed, Selector: opts.NamespaceSelector}); err != nil {
+		return err
+	}
+
+	// Optional NS filter list
+	watchNS := sets.New[string](opts.WatchNamespaces...)
+
+	// Secret controller
+	secPred := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return (watchNS.Len() == 0 || watchNS.Has(e.Object.GetNamespace())) &&
+				opts.LabelSelector.Matches(labels.Set(e.Object.GetLabels())) &&
+				allowed.Has(e.Object.GetNamespace())
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return (watchNS.Len() == 0 || watchNS.Has(e.ObjectNew.GetNamespace())) &&
+				opts.LabelSelector.Matches(labels.Set(e.ObjectNew.GetLabels())) &&
+				allowed.Has(e.ObjectNew.GetNamespace())
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool {
+			return (watchNS.Len() == 0 || watchNS.Has(e.Object.GetNamespace())) &&
+				opts.LabelSelector.Matches(labels.Set(e.Object.GetLabels())) &&
+				allowed.Has(e.Object.GetNamespace())
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}, builder.WithPredicates(secPred)).
+		WithOptions(controller.Options{
+			CacheSyncTimeout:        opts.CacheSyncTimeout,
+			RecoverPanic:            boolPtr(true),
+			RateLimiter:             workqueue.DefaultControllerRateLimiter(),
+			MaxConcurrentReconciles: opts.MaxConcurrent,
+		}).
+		Complete(r)
+}
+
+func (r *SecretMirrorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile.Result, error) {
+	log := ctrl.Log.WithName("rsip").WithValues("secret", req.NamespacedName.String())
+
+	var sec corev1.Secret
+	if err := r.Get(ctx, req.NamespacedName, &sec); err != nil {
+		return reconcile.Result{}, r.ensureRSIPAbsence(ctx, req.NamespacedName)
+	}
+
+	// filters
+	if !r.allowedNS.Has(sec.Namespace) || !r.Opts.LabelSelector.Matches(labels.Set(sec.Labels)) {
+		return reconcile.Result{}, r.ensureRSIPAbsence(ctx, req.NamespacedName)
+	}
+	if _, ok := sec.Data[r.Opts.SecretKey]; !ok {
+		log.V(1).Info("missing kubeconfig key; skipping", "key", r.Opts.SecretKey)
+		return reconcile.Result{}, nil
+	}
+
+	// names/ids
+	clusterName := sec.Labels[r.Opts.ClusterNameKey]
+	if clusterName == "" {
+		clusterName = sec.Name
+	}
+	if errs := validation.IsDNS1123Label(clusterName); len(errs) > 0 {
+		clusterName = sanitizeDNS1123(clusterName)
+	}
+	project := strings.TrimSpace(sec.Labels[r.Opts.ProjectLabelKey])
+	if project == "" {
+		project = projectFromNamespace(sec.Namespace)
+	}
+	project = sanitizeDNS1123(project)
+
+	rsipName := r.Opts.RSIPNamePrefix
+	if project != "" {
+		rsipName += project + "-"
+	}
+	rsipName += clusterName
+
+	// desired RSIP
+	desired := &unstructured.Unstructured{}
+	desired.SetGroupVersionKind(rsipGVK)
+	desired.SetNamespace(r.Opts.RSIPNamespace)
+	desired.SetName(rsipName)
+
+	lbls := map[string]string{
+		"mirror.fluxcd.io/managed":     "true",
+		"mirror.fluxcd.io/secretNS":    sec.Namespace,
+		"mirror.fluxcd.io/secretName":  sec.Name,
+		"mirror.fluxcd.io/secretKey":   r.Opts.SecretKey,
+		"mirror.fluxcd.io/clusterName": clusterName,
+		"mirror.fluxcd.io/project":     project,
+	}
+	// copy selected labels to RSIP labels
+	for _, k := range r.Opts.CopyLabelKeys {
+		if v, ok := sec.Labels[k]; ok {
+			lbls[k] = v
+		}
+	}
+	for k, v := range sec.Labels {
+		if hasAnyPrefix(r.Opts.CopyLabelPrefixes, k) {
+			lbls[k] = v
+		}
+	}
+	desired.SetLabels(lbls)
+
+	// defaultValues incl. camelCased copies of selected labels
+	dv := map[string]any{
+		"name":           clusterName,
+		"project":        project,
+		"kubeSecretName": sec.Name,
+		"kubeSecretKey":  r.Opts.SecretKey,
+		"kubeSecretNS":   sec.Namespace,
+	}
+	reserved := sets.New[string]("name", "project", "kubeSecretName", "kubeSecretKey", "kubeSecretNS")
+
+	for _, k := range r.Opts.CopyLabelKeys {
+		if v, ok := sec.Labels[k]; ok {
+			ck := toCamel(k)
+			if !reserved.Has(ck) {
+				dv[ck] = v
+			}
+		}
+	}
+	for k, v := range sec.Labels {
+		if hasAnyPrefix(r.Opts.CopyLabelPrefixes, k) {
+			ck := toCamel(k)
+			if !reserved.Has(ck) {
+				dv[ck] = v
+			}
+		}
+	}
+
+	_ = unstructured.SetNestedField(desired.Object, map[string]any{
+		"type":          "Static",
+		"defaultValues": dv,
+	}, "spec")
+
+	// create/update
+	var existing unstructured.Unstructured
+	existing.SetGroupVersionKind(rsipGVK)
+	if err := r.Get(ctx, types.NamespacedName{Name: rsipName, Namespace: r.Opts.RSIPNamespace}, &existing); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
+			return reconcile.Result{}, err
+		}
+		log.Info("created RSIP", "name", rsipName)
+		return reconcile.Result{}, nil
+	}
+
+	changed := false
+	if !maps.Equal(existing.GetLabels(), desired.GetLabels()) {
+		existing.SetLabels(desired.GetLabels())
+		changed = true
+	}
+	curSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
+	desSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+	if !mapsEqual(curSpec, desSpec) {
+		_ = unstructured.SetNestedMap(existing.Object, desSpec, "spec")
+		changed = true
+	}
+	if changed {
+		if err := r.Update(ctx, &existing); err != nil {
+			return reconcile.Result{}, err
+		}
+		log.Info("updated RSIP", "name", rsipName)
+	}
+	return reconcile.Result{}, nil
+}
+
+// ----- shared helpers (kept local; move to util/ if you reuse) -----
+
+type threadSafeSet struct {
+	mu sync.RWMutex
+	m  map[string]struct{}
+}
+func newThreadSafeSet() *threadSafeSet { return &threadSafeSet{m: map[string]struct{}{}} }
+func (s *threadSafeSet) Has(k string) bool { s.mu.RLock(); defer s.mu.RUnlock(); _, ok := s.m[k]; return ok }
+func (s *threadSafeSet) Add(k string)       { s.mu.Lock(); defer s.mu.Unlock(); s.m[k] = struct{}{} }
+func (s *threadSafeSet) Delete(k string)    { s.mu.Lock(); defer s.mu.Unlock(); delete(s.m, k) }
+
+type NamespaceSetReconciler struct {
+	client.Client
+	AllowedNS *threadSafeSet
+	Selector  labels.Selector
+}
+
+func (r *NamespaceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile.Result, error) {
+	var ns corev1.Namespace
+	if err := r.Get(ctx, req.NamespacedName, &ns); err != nil {
+		r.AllowedNS.Delete(req.Name)
+		return reconcile.Result{}, nil
+	}
+	if r.Selector.Matches(labels.Set(ns.Labels)) {
+		r.AllowedNS.Add(ns.Name)
+	} else {
+		r.AllowedNS.Delete(ns.Name)
+	}
+	return reconcile.Result{}, nil
+}
+
+// utils
+func boolPtr(b bool) *bool { return &b }
+
+func projectFromNamespace(ns string) string {
+	if strings.HasPrefix(ns, "p-") && len(ns) > 2 { return ns[2:] }
+	return ""
+}
+func sanitizeDNS1123(in string) string {
+	s := strings.ToLower(in)
+	mapper := func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' { return r }
+		return '-'
+	}
+	s = strings.Map(mapper, s)
+	s = strings.Trim(s, "-")
+	if s == "" { return "id" }
+	if len(s) > 63 { return s[:63] }
+	return s
+}
+func hasAnyPrefix(prefixes []string, key string) bool {
+	for _, p := range prefixes {
+		if p = strings.TrimSpace(p); p != "" && strings.HasPrefix(key, p) { return true }
+	}
+	return false
+}
+func mapsEqual(a, b map[string]any) bool {
+	if len(a) != len(b) { return false }
+	for k, va := range a {
+		vb, ok := b[k]; if !ok { return false }
+		switch at := va.(type) {
+		case map[string]any:
+			bt, ok := vb.(map[string]any); if !ok { return false }
+			if !mapsEqual(at, bt) { return false }
+		default:
+			if fmt.Sprintf("%v", va) != fmt.Sprintf("%v", vb) { return false }
+		}
+	}
+	return true
+}
+func toCamel(s string) string {
+	if s == "" { return s }
+	sep := func(r rune) bool { return r == '-' || r == '_' || r == '.' || r == '/' || r == ':' }
+	parts := strings.FieldsFunc(s, sep)
+	if len(parts) == 0 { return s }
+	for i := range parts { parts[i] = strings.TrimSpace(parts[i]) }
+	out := strings.ToLower(parts[0])
+	for _, p := range parts[1:] {
+		if p == "" { continue }
+		out += strings.ToUpper(p[:1]) + strings.ToLower(p[1:])
+	}
+	// strip non-alnum
+	b := strings.Builder{}
+	for _, r := range out {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') { b.WriteRune(r) }
+	}
+	return b.String()
+}


### PR DESCRIPTION
Updating to support clear separation:

- Clear separation: flag parsing & wiring in cmd/, reconcile logic in internal/controller/.
- Testable units: util/ becomes pure functions; reconciler tested with envtest or fake client.
- Standard controller-runtime features: healthz/readyz, leader election, metrics, zap logging, predicates in SetupWithManager.
- Easier CI (envtest) and RBAC generation if you add controller-tools later.